### PR TITLE
Update Club Application Form Link

### DIFF
--- a/src/app/[slug]/route.ts
+++ b/src/app/[slug]/route.ts
@@ -14,7 +14,7 @@ const redirects = {
   discord: "https://discord.gg/EqEUDnmkDZ",
   threads: "https://www.threads.com/@sliitmozilla",
   web: "https://www.sliitmozilla.org",
-  join: "https://forms.gle/1eNYuiNqd7CwbGEw6",
+  join: "https://www.sliitmozilla.org/apply/",
   ["holamozilla-2025"]: "https://forms.gle/arvimm6KUz6cAfbt9",
 } as Record<string, string>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -79,7 +79,7 @@ export default function Home() {
     {
       name: "Join the Club",
       icon: faUserPlus,
-      url: "https://forms.gle/1eNYuiNqd7CwbGEw6",
+      url: "https://www.sliitmozilla.org/apply/",
     },
   ]
 


### PR DESCRIPTION
This pull request updates the "Join the Club" link to point to the club's official application page instead of the previous Google Forms link. This change ensures that users are directed to the most current and official location for club membership applications.

Navigation and link updates:

* Updated the `join` redirect in `src/app/[slug]/route.ts` to use `https://www.sliitmozilla.org/apply/` instead of the old Google Forms URL. ([src/app/[slug]/route.tsL17-R17](diffhunk://#diff-a7fd1be8cbb97e4068935aa696810a1a9f0deb903d3d0d4b079784169a1be108L17-R17))
* Changed the "Join the Club" URL in the navigation links in `src/app/page.tsx` to match the new application page.