### PR TITLE
feat(routes): scaffold dynamic shortlink route at /l/[slug] fix (issue #36)

### DIFF
--- a/src/app/l/[slug]/route.ts
+++ b/src/app/l/[slug]/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server"
+
+export async function GET(_request: Request, { params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+
+  if (!slug) {
+    return NextResponse.json({ error: "Slug not found" }, { status: 404 })
+  }
+
+  return NextResponse.json({
+    message: "Dynamic link route scaffolded successfully",
+    slug,
+  })
+}


### PR DESCRIPTION
### Summary
Scaffolds the Next.js App Router dynamic API route handler at `/l/[slug]` to support shortlink redirection while preventing route collisions with `/admin` or `/api` (as requested in #36).

### Changes
- Created `src/app/l/[slug]/route.ts` with async `params` handling for Next.js 15+
- Extracts `slug` and returns a temporary 200 JSON confirmation response (or 404 if missing)
- Removed hardcoded redirects pending the upcoming database integration issue

### Verification
- Tested locally via `GET /l/test-slug` returning `{ "message": "Dynamic link route scaffolded successfully", "slug": "test-slug" }`
<img width="677" height="48" alt="image" src="https://github.com/user-attachments/assets/0c7d410c-2f7d-40d3-9e60-95408edc51f9" />
<img width="584" height="242" alt="image" src="https://github.com/user-attachments/assets/9c844c3a-6c60-4f37-b19e-ce924f346cf5" />


- Verified `npm run build` succeeds without type errors

Closes #36
